### PR TITLE
Update to bio_phen() as withdrawal files were not being identified

### DIFF
--- a/R/phenotype.R
+++ b/R/phenotype.R
@@ -209,7 +209,7 @@ bio_phen <- function(project_dir, field_subset_file,
 
     if (length(withdraw_files) > 0) {
         withdraw_ids <- purrr::map_df(
-            withdraw_files, ~ readr::read_csv(., col_names = "withdraw")
+            withdraw_files, ~ readr::read_csv(., col_names = "withdraw", show_col_types=FALSE)
         ) %>%
             dplyr::pull(withdraw)
 

--- a/R/phenotype.R
+++ b/R/phenotype.R
@@ -205,7 +205,7 @@ bio_phen <- function(project_dir, field_subset_file,
         dplyr::mutate_if(is.character, list(~ na_if(., "")))
 
     # withdrawals
-    withdraw_files <- list.files("raw", pattern = "^w.*csv", full.names = TRUE)
+    withdraw_files <- list.files(paste(project_dir, "raw", sep="/"), pattern = "^w.*csv", full.names = TRUE)
 
     if (length(withdraw_files) > 0) {
         withdraw_ids <- purrr::map_df(


### PR DESCRIPTION
I have added 2 tiny changes to the bio_phen() code.
Firstly, previously "raw" was provided to list.files as the directory to search for withdrawal .csv files. However, on CREATE this is searching the users working directory and not the project directory. I therefore used the paste function to tell list.file the specific location to search. 
Secondly, I turned off the messaged outputted from read_csv() so users only see the message about withdrawals being applied.